### PR TITLE
fix: updated devices in espresso & xcuitests

### DIFF
--- a/app/espresso.rb
+++ b/app/espresso.rb
@@ -38,7 +38,7 @@ key = ENV["BROWSERSTACK_ACCESSKEY"]
 			"app": app_url, 
 			"testSuite": test_url,
 			"devices": [
-				"Google Pixel-8.0", 
+				"Google Pixel 7-13.0",
 				"Google Pixel 3-10.0"
 			], 
 			"deviceLogs": true 

--- a/app/xcuitest.rb
+++ b/app/xcuitest.rb
@@ -38,8 +38,8 @@ key = ENV["BROWSERSTACK_ACCESSKEY"]
 			"app": app_url, 
 			"testSuite": test_url,
 			"devices": [
-				"iPhone 7 Plus-10.3",
-				"iPhone 8-11.0"
+				"iPhone 8-11",
+				"iPhone X-11"
 			], 
 			"deviceLogs": true 
 		}.to_json,


### PR DESCRIPTION
The espresso and xcuitests were not making it to Browserstack dashboard and there was an error which said "unprocessable entity". Apparently, the devices specified in the espresso and xcuitests were not correct (or outdated). Modified them and the tests trigger successfully now.